### PR TITLE
Add host filesystem and all devices (for gamepad) access

### DIFF
--- a/com.tic80.TIC_80.metainfo.xml
+++ b/com.tic80.TIC_80.metainfo.xml
@@ -26,6 +26,10 @@
            takes place under some technical limitations: 240x136 pixel display,
            16 color palette, 256 8x8 color sprites, 4 channel sound, etc.
         </p>
+        <p>
+           Note: Access to all devices permission required (--device=all) so that
+           gamepads can be used with this Flatpak.
+        </p>
     </description>
     <url type="homepage">https://tic80.com/</url>
     <url type="help">https://github.com/nesbox/TIC-80/wiki</url>

--- a/com.tic80.TIC_80.yaml
+++ b/com.tic80.TIC_80.yaml
@@ -10,7 +10,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --socket=pulseaudio
-  - --device=dri
+  - --device=all
 modules:
   - name: TIC-80
     buildsystem: cmake-ninja

--- a/com.tic80.TIC_80.yaml
+++ b/com.tic80.TIC_80.yaml
@@ -10,6 +10,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --socket=pulseaudio
+  - --filesystem=home
   - --device=all
 modules:
   - name: TIC-80


### PR DESCRIPTION
This should address #3 and #5 so that users of this Flatpak shouldn't have to go to Flatseal and configure those permissions in order to use gamepads with it and drag-and-drop .tic files into it.

I do not know if this PR will address #6 (probably not, but we'll see). I'm struggling myself to see where _that_ problem is coming from.

Also, when I try to build the Flatpak _locally_, I get the below build errors (I changed the absolute build path to remove local-machine-related stuff). Hopefully this won't be an issue that stops the impending remote test build(s).
```bash
Cloning into '/home/absolute/build/path/com.tic80.TIC_80/.flatpak-builder/build/TIC-80-2/vendor/blip-buf'...
fatal: transport 'file' not allowed
fatal: clone of 'file:///home/absolute/build/path/com.tic80.TIC_80/.flatpak-builder/git/https_github.com_nesbox_blip-buf.git' into submodule path '/home/absolute/build/path/com.tic80.TIC_80/.flatpak-builder/build/TIC-80-2/vendor/blip-buf' failed
Failed to clone 'vendor/blip-buf'. Retry scheduled
Cloning into '/home/absolute/build/path/com.tic80.TIC_80/.flatpak-builder/build/TIC-80-2/vendor/blip-buf'...
fatal: transport 'file' not allowed
fatal: clone of 'file:///home/absolute/build/path/com.tic80.TIC_80/.flatpak-builder/git/https_github.com_nesbox_blip-buf.git' into submodule path '/home/absolute/build/path/com.tic80.TIC_80/.flatpak-builder/build/TIC-80-2/vendor/blip-buf' failed
Failed to clone 'vendor/blip-buf' a second time, aborting
Error: module TIC-80: Child process exited with code 1
```